### PR TITLE
Sort wishlist by dungeon

### DIFF
--- a/Core/AtlasLoot.lua
+++ b/Core/AtlasLoot.lua
@@ -341,6 +341,7 @@ function AtlasLootOptions_Init()
 	AtlasLootOptionsFrameLootlinkTT:SetChecked(AtlasLootCharDB.LootlinkTT);
 	AtlasLootOptionsFrameItemSyncTT:SetChecked(AtlasLootCharDB.ItemSyncTT);
 	AtlasLootOptionsFrameShowSource:SetChecked(AtlasLootCharDB.ShowSource);
+	AtlasLootOptionsFrameWishlistGroupedByDungeon:SetChecked(AtlasLootCharDB.WishlistGroupedByDungeon);
 	AtlasLootOptionsFrameEquipCompare:SetChecked(AtlasLootCharDB.EquipCompare);
 	AtlasLootOptionsFrameOpaque:SetChecked(AtlasLootCharDB.Opaque);
 	AtlasLootOptionsFrameItemID:SetChecked(AtlasLootCharDB.ItemIDs);
@@ -369,6 +370,7 @@ function AtlasLootOptions_Fresh()
 	AtlasLootCharDB.LootlinkTT = false;
 	AtlasLootCharDB.ItemSyncTT = false;
 	AtlasLootCharDB.ShowSource = true;
+	AtlasLootCharDB.WishlistGroupedByDungeon = true;
 	AtlasLootCharDB.EquipCompare = false;
 	AtlasLootCharDB.Opaque = false;
 	AtlasLootCharDB.ItemIDs = false;
@@ -880,6 +882,21 @@ function AtlasLootOptions_ShowSourceToggle()
 	AtlasLootOptions_Init();
 end
 
+function AtlasLootOptions_WishlistGroupedByDungeonToggle()
+	if(AtlasLootCharDB.WishlistGroupedByDungeon) then
+		AtlasLootCharDB.WishlistGroupedByDungeon = false;
+	else
+		AtlasLootCharDB.WishlistGroupedByDungeon = true;
+	end
+	AtlasLootOptions_Init();
+	AtlasLoot_WishList = AtlasLoot_CategorizeWishList(AtlasLootCharDB["WishList"]);
+	local dataID = AtlasLootItemsFrame.refresh[1];
+
+	if (dataID == 'WishList') then
+		AtlasLoot_ShowWishList();
+	end
+end
+
 --[[
 AtlasLootOptions_EquipCompareToggle:
 Toggles EquipCompare. Adds a tooltip with the equipped item (if it's the case) next to the default one.
@@ -1321,7 +1338,7 @@ function AtlasLoot_ShowItemsFrame(dataID, dataSource, boss, pFrame)
 						end
 					end
 
-					if wishDataSource == "AtlasLootItems" then
+					if wishDataSource == "AtlasLootItems" and AtlasLootCharDB.WishlistGroupedByDungeon then
 						-- Set boss
 						if wishDataID and AtlasLoot_IsLootTableAvailable(wishDataID) then
 							for _, v in ipairs(AtlasLoot_Data[wishDataSource][wishDataID]) do

--- a/Core/AtlasLoot.xml
+++ b/Core/AtlasLoot.xml
@@ -1366,7 +1366,7 @@
 
 	<Frame name="AtlasLootOptionsFrame" toplevel="true" frameStrata="DIALOG" movable="true" enableMouse="true" hidden="true" parent="UIParent" enableKeyboard="true">
 		<Size>
-			<AbsDimension x="650" y="370"/>
+			<AbsDimension x="650" y="400"/>
 		</Size>
 		<Anchors>
 			<Anchor point="CENTER"/>
@@ -1516,11 +1516,29 @@
 					</OnClick>
 				</Scripts>
 			</CheckButton>
-			<CheckButton name="$parentEquipCompare" inherits="OptionsCheckButtonTemplate">
+			<CheckButton name="$parentWishlistGroupedByDungeon" inherits="OptionsCheckButtonTemplate">
 				<Anchors>
 					<Anchor point="TOPLEFT">
 						<Offset>
 							<AbsDimension x="20" y="-250"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnLoad>
+						local AL = AceLibrary("AceLocale-2.2"):new("AtlasLoot");
+						getglobal(this:GetName().."Text"):SetText("Group wishlist by dungeon");
+					</OnLoad>
+					<OnClick>
+						AtlasLootOptions_WishlistGroupedByDungeonToggle();
+					</OnClick>
+				</Scripts>
+			</CheckButton>
+			<CheckButton name="$parentEquipCompare" inherits="OptionsCheckButtonTemplate">
+				<Anchors>
+					<Anchor point="TOPLEFT">
+						<Offset>
+							<AbsDimension x="20" y="-280"/>
 						</Offset>
 					</Anchor>
 				</Anchors>
@@ -1538,7 +1556,7 @@
 				<Anchors>
 					<Anchor point="TOPLEFT">
 						<Offset>
-							<AbsDimension x="20" y="-280"/>
+							<AbsDimension x="20" y="-310"/>
 						</Offset>
 					</Anchor>
 				</Anchors>

--- a/Core/WishList.lua
+++ b/Core/WishList.lua
@@ -243,7 +243,11 @@ function AtlasLoot_CategorizeWishList(wlTable)
 			local _, _, dataID = strfind(v[5], "^(.+)|.+");
 			-- Build subheading table
 			if not subheadings[dataID] then
-				subheadings[dataID] = GetWishListSubheadingDungeon(dataID); -- AtlasLoot_GetWishListSubheadingBoss(dataID);
+				if AtlasLootCharDB.WishlistGroupedByDungeon then
+					subheadings[dataID] = GetWishListSubheadingDungeon(dataID);
+				else
+					subheadings[dataID] = AtlasLoot_GetWishListSubheadingBoss(dataID);
+				end
 				-- If search failed, replace ID like "Aldor2" to "Aldor1" and try again
 				if not subheadings[dataID] and string.find(dataID, "^%a+%d?$") then
 					subheadings[dataID] = AtlasLoot_GetWishListSubheading(string.sub(dataID, 1, string.len(dataID) - 1).."1");


### PR DESCRIPTION
Add the option to group the wishlist items by the dungeon they drop in so it's easier to see at a glance which of your wishlist items might drop from a given dungeon.

When grouped by dungeon:
<img width="709" height="812" alt="image" src="https://github.com/user-attachments/assets/6036eebd-5aec-421e-b2b5-cb009230e2a1" />

