### PR TITLE
Fix tooltip crash when a tooltip exceeds 30 lines

### DIFF
--- a/Core/Tooltip.lua
+++ b/Core/Tooltip.lua
@@ -27,13 +27,22 @@ local WrappingLines = {
 }
 
 local lines = {}
-for i = 1, 30 do
+local maxLines = 30
+for i = 1, maxLines do
 	lines[i] = {}
 end
 
 local function AddSourceLine(tooltip, sourceStr)
 	local name = tooltip:GetName()
 	local numLines = tooltip:NumLines()
+
+	if numLines > maxLines then
+		-- the buffer is pre-built for 30 lines, but long set tooltips plus
+		-- tooltip-extending addons (StatCompare etc.) can exceed that
+		for i = maxLines + 1, numLines do lines[i] = {} end
+		maxLines = numLines
+	end
+
 	local left, right
 	local leftText, rightText
 	local leftR, leftG, leftB
@@ -47,9 +56,6 @@ local function AddSourceLine(tooltip, sourceStr)
 	end
 
 	for i = 1, numLines do
-		-- the buffer is pre-built for 30 lines, but long set tooltips plus
-		-- tooltip-extending addons (StatCompare etc.) can exceed that
-		lines[i] = lines[i] or {}
 		left = _G[name.."TextLeft"..i]
 		right = _G[name.."TextRight"..i]
 		leftText = left:GetText()
@@ -72,7 +78,7 @@ local function AddSourceLine(tooltip, sourceStr)
 
 	tooltip:SetText(lines[1][1], lines[1][3], lines[1][4], lines[1][5], 1, false)
 
-	if numLines < 28 then
+	if numLines < maxLines then
 		tooltip:AddLine(sourceStr)
 	elseif lines[2][1] then
 		lines[2][1] = sourceStr.."\n"..lines[2][1]

--- a/Core/Tooltip.lua
+++ b/Core/Tooltip.lua
@@ -47,6 +47,9 @@ local function AddSourceLine(tooltip, sourceStr)
 	end
 
 	for i = 1, numLines do
+		-- the buffer is pre-built for 30 lines, but long set tooltips plus
+		-- tooltip-extending addons (StatCompare etc.) can exceed that
+		lines[i] = lines[i] or {}
 		left = _G[name.."TextLeft"..i]
 		right = _G[name.."TextRight"..i]
 		leftText = left:GetText()


### PR DESCRIPTION
Thanks for maintaining this — it's the AtlasLoot everyone on our server ends up using.

`AddSourceLine` pre-builds its line buffer for exactly 30 entries, so any item tooltip longer than that dies on every hover with:

```
Core\Tooltip.lua:56: attempt to index field '?' (a nil value)
```

and the source line never gets added. It's easy to hit in practice: a 6-piece set block alone adds ~10 tooltip lines, and tooltip-extending addons (StatCompare and friends) push past 30 on set items. Hit it live on OctoWoW with a Gilneas set warrior — constant error spam on hover (only visible with `scriptErrors` enabled, silently broken otherwise).

The fix grows the buffer on demand; the existing clear loop (`pairs`) and rebuild loop (`getn`) already handle whatever size the table reaches, so nothing else changes.